### PR TITLE
Refactor blob retrieval script

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,7 +26,7 @@ dependencies = [
  "cfg-if",
  "once_cell",
  "version_check",
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -275,7 +275,7 @@ dependencies = [
  "keccak-asm",
  "paste",
  "proptest",
- "rand",
+ "rand 0.8.5",
  "ruint",
  "rustc-hash 2.1.0",
  "serde",
@@ -469,7 +469,7 @@ dependencies = [
  "alloy-signer",
  "async-trait",
  "k256",
- "rand",
+ "rand 0.8.5",
  "thiserror 1.0.69",
 ]
 
@@ -618,6 +618,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -734,7 +749,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -744,7 +759,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -1085,6 +1100,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chrono"
+version = "0.4.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-targets",
+]
+
+[[package]]
 name = "clang-sys"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1177,7 +1206,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
@@ -1331,7 +1360,7 @@ dependencies = [
  "generic-array",
  "group",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "sec1",
  "subtle",
  "zeroize",
@@ -1407,6 +1436,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1440,7 +1475,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -1451,7 +1486,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
  "byteorder",
- "rand",
+ "rand 0.8.5",
  "rustc-hex",
  "static_assertions",
 ]
@@ -1652,7 +1687,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -1873,6 +1908,29 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -2183,7 +2241,7 @@ name = "kzgpad-rs"
 version = "0.1.0"
 source = "git+https://github.com/Layr-Labs/kzgpad-rs.git?tag=v0.1.0#b5f8c8d3d6482407dc118cb1f51597a017a1cc89"
 dependencies = [
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -2262,6 +2320,16 @@ name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest 0.10.7",
+]
 
 [[package]]
 name = "memchr"
@@ -2529,6 +2597,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2577,12 +2663,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
+name = "postgres-protocol"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ff0abab4a9b844b93ef7b81f1efc0a366062aaef2cd702c76256b5dc075c54"
+dependencies = [
+ "base64",
+ "byteorder",
+ "bytes",
+ "fallible-iterator",
+ "hmac",
+ "md-5",
+ "memchr",
+ "rand 0.9.0",
+ "sha2",
+ "stringprep",
+]
+
+[[package]]
+name = "postgres-types"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613283563cd90e1dfc3518d548caee47e0e725455ed619881f5cf21f36de4b48"
+dependencies = [
+ "bytes",
+ "chrono",
+ "fallible-iterator",
+ "postgres-protocol",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -2659,8 +2775,8 @@ dependencies = [
  "bitflags",
  "lazy_static",
  "num-traits",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "rand_xorshift",
  "regex-syntax",
  "rusty-fork",
@@ -2719,9 +2835,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
  "serde",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.0",
+ "zerocopy 0.8.17",
 ]
 
 [[package]]
@@ -2731,7 +2858,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.0",
 ]
 
 [[package]]
@@ -2744,12 +2881,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b08f3c9802962f7e1b25113931d94f43ed9725bebc59db9d0c3e9a23b67e15ff"
+dependencies = [
+ "getrandom 0.3.1",
+ "zerocopy 0.8.17",
+]
+
+[[package]]
 name = "rand_xorshift"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2893,7 +3040,7 @@ dependencies = [
  "parity-scale-codec",
  "primitive-types",
  "proptest",
- "rand",
+ "rand 0.8.5",
  "rlp",
  "ruint-macro",
  "serde",
@@ -3254,8 +3401,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest 0.10.7",
- "rand_core",
+ "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "siphasher"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "slab"
@@ -3309,6 +3462,17 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
+]
 
 [[package]]
 name = "strum"
@@ -3502,6 +3666,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "022db8904dfa342efe721985167e9fcd16c29b226db4397ed752a761cfce81e8"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3538,6 +3717,32 @@ checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
  "tokio",
+]
+
+[[package]]
+name = "tokio-postgres"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c95d533c83082bb6490e0189acaa0bbeef9084e60471b696ca6988cd0541fb0"
+dependencies = [
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "fallible-iterator",
+ "futures-channel",
+ "futures-util",
+ "log",
+ "parking_lot",
+ "percent-encoding",
+ "phf",
+ "pin-project-lite",
+ "postgres-protocol",
+ "postgres-types",
+ "rand 0.9.0",
+ "socket2",
+ "tokio",
+ "tokio-util",
+ "whoami",
 ]
 
 [[package]]
@@ -3652,7 +3857,7 @@ dependencies = [
  "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
- "rand",
+ "rand 0.8.5",
  "slab",
  "tokio",
  "tokio-util",
@@ -3739,7 +3944,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand",
+ "rand 0.8.5",
  "rustls",
  "rustls-pki-types",
  "sha1",
@@ -3778,10 +3983,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
 
 [[package]]
 name = "unicode-xid"
@@ -3874,6 +4100,12 @@ checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
 dependencies = [
  "wit-bindgen-rt",
 ]
+
+[[package]]
+name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
@@ -3978,10 +4210,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "whoami"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "372d5b87f58ec45c384ba03563b03544dc5fadc3983e434b286913f5b4a9bb6d"
+dependencies = [
+ "redox_syscall",
+ "wasite",
+ "web-sys",
+]
+
+[[package]]
 name = "widestring"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7219d36b6eac893fa81e84ebe06485e7dcbb616177469b142df14f1f4deb1311"
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-registry"
@@ -4184,7 +4436,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "byteorder",
- "zerocopy-derive",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa91407dacce3a68c56de03abe2760159582b846c6a4acd2f456618087f12713"
+dependencies = [
+ "zerocopy-derive 0.8.17",
 ]
 
 [[package]]
@@ -4192,6 +4453,17 @@ name = "zerocopy-derive"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06718a168365cad3d5ff0bb133aad346959a2074bd4a85c121255a11304a8626"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4266,8 +4538,11 @@ name = "zksync-eigenda-tools"
 version = "0.1.0"
 dependencies = [
  "alloy",
+ "alloy-primitives",
+ "alloy-sol-types",
  "anyhow",
  "axum",
+ "chrono",
  "ethabi",
  "futures",
  "hex",
@@ -4279,5 +4554,6 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tokio-postgres",
  "tonic",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1"
 tokio = { version = "1" , features = ["full"] }
+tokio-postgres = { version = "0.7", features=["with-chrono-0_4"] }
 axum = "0.7.5"
 rustls = "0.23"
 rlp = "0.5"
@@ -21,3 +22,7 @@ prost = "0.13.1"
 kzgpad-rs = { git = "https://github.com/Layr-Labs/kzgpad-rs.git", tag = "v0.1.0" }
 alloy = { version = "0.3", features = ["full"] }
 futures = "0.3"
+chrono = "0.4"
+
+alloy-primitives = { version = "0.8" }
+alloy-sol-types = { version = "0.8" }

--- a/README.md
+++ b/README.md
@@ -6,12 +6,5 @@ This is a proof of concept that demostrates how it would be possible to rebuild 
 
 Run the program with the following command:
 ```sh
-cargo run --release -- <VALIDATOR_TIMELOCK_ADDR> <ETHEREUM_ETH_RCP> <STARTING_BLOCK>
+cargo run --release
 ```
-
-If for example you want to run with a local zkstack and L1 node, you can run the following command:
-```sh
-cargo run --release -- 0x349f3f99b60bfeeb785558abbe1ede083da90b1e http://127.0.0.1:8545 0
-```
-
-Note: The `VALIDATOR_TIMELOCK_ADDR` can be found in `/chains/<chain_name>/configs/general.yaml` of the deployed zkstack.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,36 +1,21 @@
-use crate::utils::get_transactions;
-use alloy::{network::Ethereum, primitives::Address, providers::RootProvider};
-use std::str::FromStr;
+// use crate::utils::get_transactions;
+use utils::get_blobs;
 
 mod blob_info;
 mod client;
 mod generated;
 mod utils;
+mod verify_blob;
 
 const EIGENDA_API_URL: &str = "https://disperser-holesky.eigenda.xyz:443";
+const DB_CONN_CONFIG: &str = "host=localhost user=postgres password=notsecurepassword dbname=zksync_server_localhost_eigenda";
 const BLOB_DATA_JSON: &str = "blob_data.json";
-const ABI_JSON: &str = "./abi/commitBatchesSharedBridge.json";
-const COMMIT_BATCHES_SELECTOR: &str = "98f81962";
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    let args: Vec<String> = std::env::args().collect();
-
-    if args.len() != 4 {
-        eprintln!("Usage: cargo run <validatorTimelockAddress> <rpc_url> <block_start>");
-        std::process::exit(1);
-    }
-
-    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
-
-    let validator_timelock_address = Address::from_str(&args[1])?;
-    let url = alloy::transports::http::reqwest::Url::from_str(&args[2])?;
-    let provider: RootProvider<
-        alloy::transports::http::Http<alloy::transports::http::Client>,
-        Ethereum,
-    > = RootProvider::new_http(url);
-
-    let block_start = args[3].parse::<u64>()?;
-
-    get_transactions(&provider, validator_timelock_address, block_start).await
+    let blobs = get_blobs().await?;
+    let json_string = serde_json::to_string_pretty(&blobs)?;
+    std::fs::write(BLOB_DATA_JSON, json_string)?;
+    println!("\x1b[32mData stored in blob_data.json file.\x1b[0m");
+    Ok(())
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,66 +1,48 @@
-use std::fs;
+use tokio_postgres::NoTls;
 
 use crate::{
-    blob_info::{
-        BatchHeader, BatchMetadata, BlobHeader, BlobInfo, BlobQuorumParam, BlobVerificationProof,
-        G1Commitment,
-    },
-    client::EigenClientRetriever,
-    ABI_JSON, BLOB_DATA_JSON, COMMIT_BATCHES_SELECTOR, EIGENDA_API_URL,
+    blob_info::BlobInfo, client::EigenClientRetriever, verify_blob::decode_blob_info,
+    DB_CONN_CONFIG, EIGENDA_API_URL,
 };
-use alloy::{
-    dyn_abi::{DynSolValue, JsonAbiExt},
-    json_abi::JsonAbi,
-    network::Ethereum,
-    primitives::Address,
-    providers::{Provider, RootProvider},
-};
-use ethabi::{ParamType, Token};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]
-struct BlobData {
+pub struct BlobData {
     pub blob_info: BlobInfo,
     pub blob: Vec<u8>,
 }
 
-/// Helper functions for safe extraction
-fn extract_tuple(token: &Token) -> anyhow::Result<&Vec<Token>> {
-    match token {
-        Token::Tuple(inner) => Ok(inner),
-        _ => Err(anyhow::anyhow!("Not a tuple")),
+// Retrieve each blob's blob_info from the database
+async fn get_blobs_info_from_db() -> anyhow::Result<Vec<BlobInfo>> {
+    let (db_client, db_connection) = tokio_postgres::connect(DB_CONN_CONFIG, NoTls).await?;
+
+    tokio::spawn(async move {
+        if let Err(e) = db_connection.await {
+            eprintln!("connection error: {}", e);
+        }
+    });
+
+    let timestamp =
+        chrono::NaiveDateTime::parse_from_str("1970-01-01 00:00:00", "%Y-%m-%d %H:%M:%S")?;
+    let rows = db_client
+            .query("SELECT inclusion_data, sent_at FROM data_availability WHERE sent_at > $1 AND inclusion_data IS NOT NULL ORDER BY sent_at", &[&timestamp])
+            .await?;
+
+    println!("Retrieved {} blobs from the database", rows.len());
+
+    let mut blobs_info = Vec::new();
+    for row in rows {
+        let inclusion_data = row.get(0);
+        let (blob_header, blob_verification_proof) = decode_blob_info(inclusion_data)?;
+        blobs_info.push(BlobInfo {
+            blob_header: blob_header.into(),
+            blob_verification_proof: blob_verification_proof.into(),
+        });
     }
+    Ok(blobs_info)
 }
 
-fn extract_array(token: &Token) -> anyhow::Result<Vec<Token>> {
-    match token {
-        Token::Array(tokens) => Ok(tokens.clone()),
-        _ => Err(anyhow::anyhow!("Not a uint")),
-    }
-}
-
-fn extract_uint(token: &Token) -> anyhow::Result<u32> {
-    match token {
-        Token::Uint(value) => Ok(value.as_u32()),
-        _ => Err(anyhow::anyhow!("Not a uint")),
-    }
-}
-
-fn extract_fixed_bytes<const N: usize>(token: &Token) -> anyhow::Result<Vec<u8>> {
-    match token {
-        Token::FixedBytes(bytes) => Ok(bytes.clone()),
-        _ => Err(anyhow::anyhow!("Not fixed bytes")),
-    }
-}
-
-fn extract_bytes(token: &Token) -> anyhow::Result<Vec<u8>> {
-    match token {
-        Token::Bytes(bytes) => Ok(bytes.clone()),
-        _ => Err(anyhow::anyhow!("Not bytes")),
-    }
-}
-
-async fn get_blob(blob_info: BlobInfo) -> anyhow::Result<Vec<u8>> {
+async fn get_blob_from_disperser(blob_info: BlobInfo) -> anyhow::Result<Vec<u8>> {
     let client = EigenClientRetriever::new(EIGENDA_API_URL).await?;
     let data = client
         .get_blob_data(blob_info)
@@ -70,262 +52,15 @@ async fn get_blob(blob_info: BlobInfo) -> anyhow::Result<Vec<u8>> {
     Ok(data)
 }
 
-pub(crate) async fn get_transactions(
-    provider: &RootProvider<
-        alloy::transports::http::Http<alloy::transports::http::Client>,
-        Ethereum,
-    >,
-    validator_timelock_address: Address,
-    block_start: u64,
-) -> anyhow::Result<()> {
-    let latest_block = provider.get_block_number().await?;
-    let mut json_array = Vec::new();
+pub async fn get_blobs() -> anyhow::Result<Vec<BlobData>> {
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
 
-    let mut i = 0;
-    for block_number in block_start..=latest_block {
-        i += 1;
-        if i % 50 == 0 {
-            println!(
-                "\x1b[32mProcessed up to block {} of {}\x1b[0m",
-                block_number, latest_block
-            );
-        }
-        if let Ok(Some(block)) = provider
-            .get_block_by_number(block_number.into(), true)
-            .await
-        {
-            for tx in block.transactions.into_transactions() {
-                if let Some(to) = tx.to {
-                    if to == validator_timelock_address {
-                        let input = tx.clone().input;
-                        let selector = &input[0..4];
-                        if selector == hex::decode(COMMIT_BATCHES_SELECTOR)? {
-                            match decode_blob_data_input(&input[4..]).await {
-                                Ok(decoded) => {
-                                    for blob in decoded {
-                                        json_array.push(blob);
-                                    }
-                                }
-                                Err(e) => {
-                                    eprintln!("\x1b[31mError decoding blob data: {}\x1b[0m", e);
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
+    let mut blobs_data = Vec::new();
+    let blob_infos = get_blobs_info_from_db().await?;
+    for blob_info in blob_infos {
+        let blob = get_blob_from_disperser(blob_info.clone()).await?;
+        let blob_data = BlobData { blob_info, blob };
+        blobs_data.push(blob_data);
     }
-
-    if json_array.is_empty() {
-        println!("\x1b[31mNo transactions found.\x1b[0m");
-        return Ok(());
-    }
-
-    let json_string = serde_json::to_string_pretty(&json_array)?;
-    fs::write(BLOB_DATA_JSON, json_string)?;
-    println!("\x1b[32mData stored in blob_data.json file.\x1b[0m");
-
-    Ok(())
-}
-
-async fn decode_blob_data_input(input: &[u8]) -> anyhow::Result<Vec<BlobData>> {
-    let json = std::fs::read_to_string(ABI_JSON)?;
-    let json_abi: JsonAbi = serde_json::from_str(&json)?;
-    let function = json_abi
-        .functions
-        .iter()
-        .find(|f| f.0 == "commitBatchesSharedBridge")
-        .ok_or(anyhow::anyhow!("Function not found"))?
-        .1;
-    let decoded = function[0].abi_decode_input(input, true)?;
-    let commit_data = &decoded[3];
-    let commit_data = match commit_data {
-        DynSolValue::Bytes(commit_data) => commit_data,
-        _ => return Err(anyhow::anyhow!("Commit data is not bytes")),
-    };
-
-    let param_types = vec![
-        ParamType::Tuple(vec![
-            ParamType::Uint(64),
-            ParamType::FixedBytes(32),
-            ParamType::Uint(64),
-            ParamType::Uint(256),
-            ParamType::FixedBytes(32),
-            ParamType::FixedBytes(32),
-            ParamType::Uint(256),
-            ParamType::FixedBytes(32),
-        ]), // StoredBatchInfo
-        ParamType::Array(Box::new(ParamType::Tuple(vec![
-            ParamType::Uint(64),
-            ParamType::Uint(64),
-            ParamType::Uint(64),
-            ParamType::FixedBytes(32),
-            ParamType::Uint(64),
-            ParamType::FixedBytes(32),
-            ParamType::FixedBytes(32),
-            ParamType::FixedBytes(32),
-            ParamType::Bytes,
-            ParamType::Bytes,
-        ]))), // CommitBatchInfo
-    ];
-
-    let decoded = ethabi::decode(&param_types, &commit_data[1..])?;
-
-    let commit_batch_info = if let Some(Token::Array(commit_batch_info)) = decoded.get(1) {
-        commit_batch_info
-    } else {
-        return Err(anyhow::anyhow!("CommitBatchInfo is not an array"));
-    };
-
-    let mut blobs = vec![];
-    for batch_info in commit_batch_info {
-        if let Token::Tuple(batch_info) = batch_info {
-            if let Some(Token::Bytes(operator_da_input)) = batch_info.get(9) {
-                match get_blob_from_operator_da_input(operator_da_input.clone()).await {
-                    Ok(blob_data) => blobs.push(blob_data),
-                    Err(_) => return Err(anyhow::anyhow!("Error getting blob data")),
-                }
-            } else {
-                return Err(anyhow::anyhow!("Operator DA input is not bytes"));
-            }
-        } else {
-            return Err(anyhow::anyhow!(
-                "CommitBatchInfo components cannot be represented as a tuple"
-            ));
-        }
-    }
-
-    Ok(blobs)
-}
-
-async fn get_blob_header(blob_header_tokens: &[Token]) -> anyhow::Result<BlobHeader> {
-    let commitment_tokens = extract_tuple(&blob_header_tokens[0])?;
-
-    let x = commitment_tokens[0]
-        .clone()
-        .into_uint()
-        .ok_or(anyhow::anyhow!("x is not a uint"))?;
-    let y = commitment_tokens[1]
-        .clone()
-        .into_uint()
-        .ok_or(anyhow::anyhow!("y is not a uint"))?;
-
-    let mut x_bytes = vec![0u8; 32];
-    let mut y_bytes = vec![0u8; 32];
-    x.to_big_endian(&mut x_bytes);
-    y.to_big_endian(&mut y_bytes);
-
-    let data_length = extract_uint(&blob_header_tokens[1])?;
-    let blob_quorum_params_tokens = extract_array(&blob_header_tokens[2])?;
-
-    let blob_quorum_params: Vec<BlobQuorumParam> = blob_quorum_params_tokens
-        .iter()
-        .map(|param| {
-            let tuple = extract_tuple(param)?;
-            Ok(BlobQuorumParam {
-                quorum_number: extract_uint(&tuple[0])?,
-                adversary_threshold_percentage: extract_uint(&tuple[1])?,
-                confirmation_threshold_percentage: extract_uint(&tuple[2])?,
-                chunk_length: extract_uint(&tuple[3])?,
-            })
-        })
-        .collect::<anyhow::Result<Vec<_>>>()?;
-
-    let blob_header = BlobHeader {
-        commitment: G1Commitment {
-            x: x_bytes,
-            y: y_bytes,
-        },
-        data_length,
-        blob_quorum_params,
-    };
-    Ok(blob_header)
-}
-
-async fn get_blob_verification_proof(
-    blob_verification_tokens: &[Token],
-) -> anyhow::Result<BlobVerificationProof> {
-    let batch_id = extract_uint(&blob_verification_tokens[0])?;
-    let blob_index = extract_uint(&blob_verification_tokens[1])?;
-
-    let batch_metadata_tokens = extract_tuple(&blob_verification_tokens[2])?;
-    let batch_header_tokens = extract_tuple(&batch_metadata_tokens[0])?;
-
-    let batch_header = BatchHeader {
-        batch_root: extract_fixed_bytes::<32>(&batch_header_tokens[0])?,
-        quorum_numbers: extract_bytes(&batch_header_tokens[1])?,
-        quorum_signed_percentages: extract_bytes(&batch_header_tokens[2])?,
-        reference_block_number: extract_uint(&batch_header_tokens[3])?,
-    };
-
-    let batch_metadata = BatchMetadata {
-        batch_header,
-        signatory_record_hash: extract_fixed_bytes::<32>(&batch_metadata_tokens[1])?,
-        confirmation_block_number: extract_uint(&batch_metadata_tokens[2])?,
-        batch_header_hash: extract_bytes(&batch_metadata_tokens[3])?,
-        fee: extract_bytes(&batch_metadata_tokens[4])?,
-    };
-
-    let blob_verification_proof = BlobVerificationProof {
-        batch_id,
-        blob_index,
-        batch_metadata,
-        inclusion_proof: extract_bytes(&blob_verification_tokens[3])?,
-        quorum_indexes: extract_bytes(&blob_verification_tokens[4])?,
-    };
-
-    Ok(blob_verification_proof)
-}
-
-async fn get_blob_from_operator_da_input(operator_da_input: Vec<u8>) -> anyhow::Result<BlobData> {
-    let param_types = vec![ParamType::Tuple(vec![
-        // BlobHeader
-        ParamType::Tuple(vec![
-            ParamType::Tuple(vec![ParamType::Uint(256), ParamType::Uint(256)]), // G1Commitment
-            ParamType::Uint(32),                                                // data_length
-            ParamType::Array(Box::new(ParamType::Tuple(vec![
-                ParamType::Uint(32),
-                ParamType::Uint(32),
-                ParamType::Uint(32),
-                ParamType::Uint(32),
-            ]))), // BlobQuorumParam
-        ]),
-        // BlobVerificationProof
-        ParamType::Tuple(vec![
-            ParamType::Uint(32), // batch_id
-            ParamType::Uint(32), // blob_index
-            ParamType::Tuple(vec![
-                ParamType::Tuple(vec![
-                    ParamType::FixedBytes(32),
-                    ParamType::Bytes,
-                    ParamType::Bytes,
-                    ParamType::Uint(32),
-                ]), // BatchHeader
-                ParamType::FixedBytes(32), // signatory_record_hash
-                ParamType::Uint(32),       // confirmation_block_number
-                ParamType::Bytes,          // batch_header_hash
-                ParamType::Bytes,          // fee
-            ]), // BatchMetadata
-            ParamType::Bytes,    // inclusion_proof
-            ParamType::Bytes,    // quorum_indexes
-        ]),
-    ])];
-
-    let decoded = ethabi::decode(&param_types, &operator_da_input[32..])?;
-    let blob_info = extract_tuple(&decoded[0])?;
-
-    let blob_header_tokens = extract_tuple(&blob_info[0])?;
-    let blob_header = get_blob_header(blob_header_tokens).await?;
-
-    let blob_verification_tokens = extract_tuple(&blob_info[1])?;
-    let blob_verification_proof = get_blob_verification_proof(blob_verification_tokens).await?;
-
-    let blob_info = BlobInfo {
-        blob_header,
-        blob_verification_proof,
-    };
-
-    let blob = get_blob(blob_info.clone()).await?;
-    Ok(BlobData { blob_info, blob })
+    Ok(blobs_data)
 }

--- a/src/verify_blob.rs
+++ b/src/verify_blob.rs
@@ -1,0 +1,285 @@
+use crate::blob_info::G1Commitment;
+
+use alloy_primitives::U256;
+use alloy_primitives::{Bytes, FixedBytes};
+use alloy_sol_types::sol;
+use ethabi::{ParamType, Token};
+
+/// Helper functions for safe extraction
+pub fn extract_tuple(token: &Token) -> anyhow::Result<&Vec<Token>> {
+    match token {
+        Token::Tuple(inner) => Ok(inner),
+        _ => Err(anyhow::anyhow!("Not a tuple")),
+    }
+}
+
+pub fn extract_array(token: &Token) -> anyhow::Result<Vec<Token>> {
+    match token {
+        Token::Array(tokens) => Ok(tokens.clone()),
+        _ => Err(anyhow::anyhow!("Not a uint")),
+    }
+}
+
+pub fn extract_uint32(token: &Token) -> anyhow::Result<u32> {
+    match token {
+        Token::Uint(value) => Ok(value.as_u32()),
+        _ => Err(anyhow::anyhow!("Not a uint")),
+    }
+}
+
+pub fn extract_uint8(token: &Token) -> anyhow::Result<u8> {
+    match token {
+        Token::Uint(value) => Ok(value.as_u32() as u8),
+        _ => Err(anyhow::anyhow!("Not a uint")),
+    }
+}
+
+pub fn extract_fixed_bytes<const N: usize>(token: &Token) -> anyhow::Result<FixedBytes<32>> {
+    match token {
+        Token::FixedBytes(bytes) => Ok(FixedBytes::from_slice(bytes)),
+        _ => Err(anyhow::anyhow!("Not fixed bytes")),
+    }
+}
+
+pub fn extract_bytes(token: &Token) -> anyhow::Result<Bytes> {
+    match token {
+        Token::Bytes(bytes) => Ok(Bytes::from_iter(bytes)),
+        _ => Err(anyhow::anyhow!("Not bytes")),
+    }
+}
+
+sol! {
+    struct QuorumBlobParam {
+        uint8 quorumNumber;
+        uint8 adversaryThresholdPercentage;
+        uint8 confirmationThresholdPercentage;
+        uint32 chunkLength;
+    }
+
+    struct G1Point {
+        uint256 x;
+        uint256 y;
+    }
+
+    struct BlobHeader {
+        G1Point commitment;
+        uint32 dataLength;
+        QuorumBlobParam[] quorumBlobParams;
+    }
+
+    struct ReducedBatchHeader {
+        bytes32 blobHeadersRoot;
+        uint32 referenceBlockNumber;
+    }
+
+    struct BatchHeader {
+        bytes32 blobHeadersRoot;
+        bytes quorumNumbers;
+        bytes signedStakeForQuorums;
+        uint32 referenceBlockNumber;
+    }
+
+    struct BatchMetadata {
+        BatchHeader batchHeader;
+        bytes32 signatoryRecordHash;
+        uint32 confirmationBlockNumber;
+    }
+
+    struct BlobVerificationProof {
+        uint32 batchId;
+        uint32 blobIndex;
+        BatchMetadata batchMetadata;
+        bytes inclusionProof;
+        bytes quorumIndices;
+    }
+
+    /// VerifyBlobV1 function signature.
+    /// This must match the signature in the guest.
+    interface IVerifyBlob {
+        function verifyBlobV1(BlobHeader calldata blobHeader, BlobVerificationProof calldata blobVerificationProof) external view returns (bool);
+    }
+}
+
+impl From<G1Point> for G1Commitment {
+    fn from(point: G1Point) -> Self {
+        G1Commitment {
+            x: point.x.to_be_bytes_vec(),
+            y: point.y.to_be_bytes_vec(),
+        }
+    }
+}
+
+impl From<QuorumBlobParam> for crate::blob_info::BlobQuorumParam {
+    fn from(param: QuorumBlobParam) -> Self {
+        crate::blob_info::BlobQuorumParam {
+            quorum_number: param.quorumNumber as u32,
+            adversary_threshold_percentage: param.adversaryThresholdPercentage as u32,
+            confirmation_threshold_percentage: param.confirmationThresholdPercentage as u32,
+            chunk_length: param.chunkLength,
+        }
+    }
+}
+
+impl From<BlobHeader> for crate::blob_info::BlobHeader {
+    fn from(header: BlobHeader) -> Self {
+        crate::blob_info::BlobHeader {
+            commitment: header.commitment.into(),
+            data_length: header.dataLength,
+            blob_quorum_params: header
+                .quorumBlobParams
+                .iter()
+                .map(|param| crate::blob_info::BlobQuorumParam::from(param.clone()))
+                .collect(),
+        }
+    }
+}
+
+impl From<BatchHeader> for crate::blob_info::BatchHeader {
+    fn from(header: BatchHeader) -> Self {
+        crate::blob_info::BatchHeader {
+            batch_root: header.blobHeadersRoot.to_vec(),
+            quorum_numbers: header.quorumNumbers.to_vec(),
+            quorum_signed_percentages: header.signedStakeForQuorums.to_vec(),
+            reference_block_number: header.referenceBlockNumber,
+        }
+    }
+}
+
+impl From<BatchMetadata> for crate::blob_info::BatchMetadata {
+    fn from(metadata: BatchMetadata) -> Self {
+        crate::blob_info::BatchMetadata {
+            batch_header: crate::blob_info::BatchHeader::from(metadata.batchHeader),
+            signatory_record_hash: metadata.signatoryRecordHash.to_vec(),
+            confirmation_block_number: metadata.confirmationBlockNumber,
+            fee: vec![],
+            batch_header_hash: vec![],
+        }
+    }
+}
+
+impl From<BlobVerificationProof> for crate::blob_info::BlobVerificationProof {
+    fn from(proof: BlobVerificationProof) -> Self {
+        crate::blob_info::BlobVerificationProof {
+            batch_id: proof.batchId,
+            blob_index: proof.blobIndex,
+            batch_metadata: crate::blob_info::BatchMetadata::from(proof.batchMetadata),
+            inclusion_proof: proof.inclusionProof.to_vec(),
+            quorum_indexes: proof.quorumIndices.to_vec(),
+        }
+    }
+}
+
+pub fn decode_blob_info(
+    inclusion_data: Vec<u8>,
+) -> Result<(BlobHeader, BlobVerificationProof), anyhow::Error> {
+    let param_types = vec![ParamType::Tuple(vec![
+        // BlobHeader
+        ParamType::Tuple(vec![
+            ParamType::Tuple(vec![ParamType::Uint(256), ParamType::Uint(256)]), // G1Commitment
+            ParamType::Uint(32),                                                // data_length
+            ParamType::Array(Box::new(ParamType::Tuple(vec![
+                ParamType::Uint(32),
+                ParamType::Uint(32),
+                ParamType::Uint(32),
+                ParamType::Uint(32),
+            ]))), // BlobQuorumParam
+        ]),
+        // BlobVerificationProof
+        ParamType::Tuple(vec![
+            ParamType::Uint(32), // batch_id
+            ParamType::Uint(32), // blob_index
+            ParamType::Tuple(vec![
+                ParamType::Tuple(vec![
+                    ParamType::FixedBytes(32),
+                    ParamType::Bytes,
+                    ParamType::Bytes,
+                    ParamType::Uint(32),
+                ]), // BatchHeader
+                ParamType::FixedBytes(32), // signatory_record_hash
+                ParamType::Uint(32),       // confirmation_block_number
+                ParamType::Bytes,          // batch_header_hash
+                ParamType::Bytes,          // fee
+            ]), // BatchMetadata
+            ParamType::Bytes,    // inclusion_proof
+            ParamType::Bytes,    // quorum_indexes
+        ]),
+    ])];
+
+    let decoded = ethabi::decode(&param_types, &inclusion_data)?;
+    let blob_info = extract_tuple(&decoded[0])?;
+
+    // Extract BlobHeader
+    let blob_header_tokens = extract_tuple(&blob_info[0])?;
+    let commitment_tokens = extract_tuple(&blob_header_tokens[0])?;
+
+    let x = commitment_tokens[0]
+        .clone()
+        .into_uint()
+        .ok_or(anyhow::anyhow!("Invalid x"))?;
+    let y = commitment_tokens[1]
+        .clone()
+        .into_uint()
+        .ok_or(anyhow::anyhow!("Invalid y"))?;
+
+    let mut x_bytes = [0u8; 32];
+    let mut y_bytes = [0u8; 32];
+    x.to_big_endian(&mut x_bytes);
+    y.to_big_endian(&mut y_bytes);
+
+    let data_length = extract_uint32(&blob_header_tokens[1])?;
+    let blob_quorum_params_tokens = extract_array(&blob_header_tokens[2])?;
+
+    let blob_quorum_params: Vec<QuorumBlobParam> = blob_quorum_params_tokens
+        .iter()
+        .map(|param| {
+            let tuple = extract_tuple(param)?;
+            Ok(QuorumBlobParam {
+                quorumNumber: extract_uint8(&tuple[0])?,
+                adversaryThresholdPercentage: extract_uint8(&tuple[1])?,
+                confirmationThresholdPercentage: extract_uint8(&tuple[2])?,
+                chunkLength: extract_uint32(&tuple[3])?,
+            })
+        })
+        .collect::<anyhow::Result<Vec<_>>>()?;
+
+    let blob_header = BlobHeader {
+        commitment: G1Point {
+            x: U256::from_be_bytes(x_bytes),
+            y: U256::from_be_bytes(y_bytes),
+        },
+        dataLength: data_length,
+        quorumBlobParams: blob_quorum_params,
+    };
+
+    // Extract BlobVerificationProof
+    let blob_verification_tokens = extract_tuple(&blob_info[1])?;
+
+    let batch_id = extract_uint32(&blob_verification_tokens[0])?;
+    let blob_index = extract_uint32(&blob_verification_tokens[1])?;
+
+    let batch_metadata_tokens = extract_tuple(&blob_verification_tokens[2])?;
+    let batch_header_tokens = extract_tuple(&batch_metadata_tokens[0])?;
+
+    let batch_header = BatchHeader {
+        blobHeadersRoot: extract_fixed_bytes::<32>(&batch_header_tokens[0])?,
+        quorumNumbers: extract_bytes(&batch_header_tokens[1])?,
+        signedStakeForQuorums: extract_bytes(&batch_header_tokens[2])?,
+        referenceBlockNumber: extract_uint32(&batch_header_tokens[3])?,
+    };
+
+    let batch_metadata = BatchMetadata {
+        batchHeader: batch_header,
+        signatoryRecordHash: extract_fixed_bytes::<32>(&batch_metadata_tokens[1])?,
+        confirmationBlockNumber: extract_uint32(&batch_metadata_tokens[2])?,
+    };
+
+    let blob_verification_proof = BlobVerificationProof {
+        batchId: batch_id,
+        blobIndex: blob_index,
+        batchMetadata: batch_metadata,
+        inclusionProof: extract_bytes(&blob_verification_tokens[3])?,
+        quorumIndices: extract_bytes(&blob_verification_tokens[4])?,
+    };
+
+    Ok((blob_header, blob_verification_proof))
+}

--- a/src/verify_blob.rs
+++ b/src/verify_blob.rs
@@ -83,6 +83,8 @@ sol! {
         BatchHeader batchHeader;
         bytes32 signatoryRecordHash;
         uint32 confirmationBlockNumber;
+        bytes batch_header_hash;
+        bytes fee;
     }
 
     struct BlobVerificationProof {
@@ -151,8 +153,8 @@ impl From<BatchMetadata> for crate::blob_info::BatchMetadata {
             batch_header: crate::blob_info::BatchHeader::from(metadata.batchHeader),
             signatory_record_hash: metadata.signatoryRecordHash.to_vec(),
             confirmation_block_number: metadata.confirmationBlockNumber,
-            fee: vec![],
-            batch_header_hash: vec![],
+            fee: metadata.fee.to_vec(),
+            batch_header_hash: metadata.batch_header_hash.to_vec(),
         }
     }
 }
@@ -271,6 +273,8 @@ pub fn decode_blob_info(
         batchHeader: batch_header,
         signatoryRecordHash: extract_fixed_bytes::<32>(&batch_metadata_tokens[1])?,
         confirmationBlockNumber: extract_uint32(&batch_metadata_tokens[2])?,
+        batch_header_hash: extract_bytes(&batch_metadata_tokens[3])?,
+        fee: extract_bytes(&batch_metadata_tokens[4])?,
     };
 
     let blob_verification_proof = BlobVerificationProof {


### PR DESCRIPTION
Update blob retrieval script to get inclusion data from the zksync db instead of L1.

To test this changes, use branch `eigenda-m0` of `lambdaclass:zksync-era`.

This change comes from the decision to [postpone era-contrac changes until M1](https://github.com/matter-labs/era-contracts/pull/1233#pullrequestreview-2614674943).